### PR TITLE
Support for armada38x CPUs

### DIFF
--- a/arch.desc
+++ b/arch.desc
@@ -4,5 +4,5 @@
 386 x86
 amd64 cedarview bromolow denverton apollolake
 arm-5 88f6281 88f6282
-arm-7 armada370 armada375 armadaxp alpine/alpine4k comcerto2k
+arm-7 armada370 armada375 armada38x armadaxp alpine/alpine4k comcerto2k
 arm64 rtd1296


### PR DESCRIPTION
Adding armada38x to arch.desc now supports the following DiskStations with Armada 385 CPU:

- DS216j
- DS218j
- DS416slim
- DS116
- DS216